### PR TITLE
$ char in dbpw needs to be single quoted

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,7 +97,7 @@ TMPL
   config.vm.provision "shell", inline: <<-SHELL
      RUBYVER=2.3.3
      HOMEDIR=/home/vagrant
-     echo "#{dbpw}" > "${HOMEDIR}/.dbpassword"
+     echo '#{dbpw}' > "${HOMEDIR}/.dbpassword"
      chown vagrant.vagrant ${HOMEDIR}/.dbpassword
      chmod 0600 ${HOMEDIR}/.dbpassword
      yum update -y


### PR DESCRIPTION
Fixes this error when running the provisioning script:

==> default: Running provisioner: shell...
    default: Running: inline script
==> default: /tmp/vagrant-shell: line 74: unexpected EOF while looking for matching`"'
==> default: /tmp/vagrant-shell: line 75: syntax error: unexpected end of file
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.