### PR TITLE
Add support for new rollup_id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/trln/argot-ruby.git
-  revision: 38111567743496603043a895b06619c628c8d63c
+  revision: d64b57563eab2475d1b4538f00541a4d8e9ed75b
   specs:
-    argot (0.6.8)
+    argot (0.6.9)
       rsolr (~> 1.1, >= 1.1.2)
       rubyzip (~> 1.2)
       thor (~> 0.19.4)
@@ -133,7 +133,7 @@ GEM
     popper_js (1.14.3)
     puma (3.12.0)
     rack (2.0.5)
-    rack-protection (2.0.3)
+    rack-protection (2.0.4)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -183,7 +183,7 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     scrub_rb (1.0.1)
-    sidekiq (5.2.1)
+    sidekiq (5.2.2)
       connection_pool (~> 2.2, >= 2.2.2)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)

--- a/lib/spofford/version.rb
+++ b/lib/spofford/version.rb
@@ -1,3 +1,3 @@
 module Spofford
-  VERSION = '0.3.5'.freeze
+  VERSION = '0.3.6'.freeze
 end


### PR DESCRIPTION
Updates `argot-ruby` to 0.6.9