### PR TITLE
Update argot to v0.6.20; Use /document&id= to fetch Solr document.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/trln/argot-ruby.git
-  revision: 6f8c9bec215162ea3c5eeec0d3e56ef757e702c8
+  revision: b2fa26c0c9704b2c9b555c629d4c82f4f79dc201
   specs:
-    argot (0.6.19)
+    argot (0.6.20)
       rsolr (~> 1.1, >= 1.1.2)
       rubyzip (~> 1.2)
       thor (~> 0.20.0)

--- a/lib/spofford/argot_viewer.rb
+++ b/lib/spofford/argot_viewer.rb
@@ -18,7 +18,7 @@ module Spofford
     def fetch_solr(doc_id)
       result = {}
       SolrService.new do |service|
-        response = service.client.get :select, params: { q: "id:#{doc_id}" }
+        response = service.client.get :document, params: { id: doc_id }
         dr = response['response']
         result = dr['docs'].first if dr && !dr['docs'].empty?
       end

--- a/lib/spofford/version.rb
+++ b/lib/spofford/version.rb
@@ -1,3 +1,3 @@
 module Spofford
-  VERSION = '0.3.91'.freeze
+  VERSION = '0.3.92'.freeze
 end


### PR DESCRIPTION
The recent change that set `uf=-*` by default for the select request handler in Solr prevented the previous `select/?q=id:DOC_ID` query from working. I opted to use the document request handler instead of passing `uf=id` with the request.