### PR TITLE
Fix vagrant provision

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,8 @@ gem 'active_record_upsert', platform: :mri
 # :github specifier defaults to using git:// protocol, which generates
 # warnings. See comment at top of file.
 
-gem 'argot', '>= 0.3.9', github: 'trln/argot-ruby'
+# gem 'argot', '>= 0.3.9', github: 'trln/argot-ruby'
+gem 'argot', github: 'trln/argot-ruby', branch: 'TD-1006-name-authority'
 
 gem 'solrtasks', github: 'trln/solrtasks'
 
@@ -124,6 +125,8 @@ group :test do
   gem 'pry-byebug'
   #gem 'warden'
   gem 'timecop', '~> 0.9.1'
+  gem 'mock_redis', '~> 0.27'
+  gem 'minitest-stub-const'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GIT
   remote: https://github.com/trln/argot-ruby.git
-  revision: 7fff156ff54171f350b6e39c2c97a54e82dad508
+  revision: 731249eceae11c9542c91e33648389f69888f94a
+  branch: TD-1006-name-authority
   specs:
-    argot (1.0.2)
+    argot (1.0.5)
       nokogiri (~> 1.10)
       rsolr (~> 1.1, >= 1.1.2)
       rubyzip (~> 1.2)
@@ -12,9 +13,9 @@ GIT
 
 GIT
   remote: https://github.com/trln/solrtasks.git
-  revision: 8f180c6464734c76865e4ddd1ab829e99277dbc5
+  revision: c463013d783bad2f9e61a9444914e8587329c9e2
   specs:
-    solrtasks (0.2.6)
+    solrtasks (0.2.7)
       cocaine (~> 0.5.8)
       nokogiri (>= 1.10)
 
@@ -44,8 +45,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_record_upsert (0.9.5)
-      activerecord (>= 5.0, < 6.1)
+    active_record_upsert (0.10.0)
+      activerecord (>= 5.0, < 6.2)
       pg (>= 0.18, < 2.0)
     activejob (5.1.7)
       activesupport (= 5.1.7)
@@ -62,9 +63,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
-    autoprefixer-rails (9.7.6)
+    autoprefixer-rails (10.2.4.0)
       execjs
-    bcrypt (3.1.13)
+    bcrypt (3.1.16)
     bindex (0.8.1)
     bootstrap (4.3.1)
       autoprefixer-rails (>= 9.1.0)
@@ -75,29 +76,29 @@ GEM
     climate_control (0.2.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
-    coderay (1.1.2)
-    concurrent-ruby (1.1.6)
-    connection_pool (2.2.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.8)
+    connection_pool (2.2.3)
     crass (1.0.6)
-    devise (4.7.1)
+    devise (4.7.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
     dot-properties (0.1.3)
-    erubi (1.9.0)
+    erubi (1.10.0)
     execjs (2.7.0)
-    ffi (1.12.2)
+    ffi (1.14.2)
     git (1.3.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashids (1.0.5)
     hashie (3.6.0)
     httpclient (2.8.3)
-    i18n (1.8.2)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    jbuilder (2.10.0)
+    jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -115,12 +116,12 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
-    libv8 (7.3.492.27.1)
+    libv8 (8.4.255.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     local_time (2.0.1)
-    loofah (2.5.0)
+    loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -133,12 +134,16 @@ GEM
     method_source (1.0.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
-    mini_racer (0.2.14)
-      libv8 (> 7.3)
-    minitest (5.14.1)
-    nio4r (2.5.2)
-    nokogiri (1.11.0.rc2)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
+    minitest (5.14.3)
+    minitest-stub-const (0.6)
+    mock_redis (0.27.3)
+      ruby2_keywords
+    nio4r (2.5.5)
+    nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
     popper_js (1.16.0)
@@ -148,10 +153,11 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    puma (4.3.5)
+    puma (5.2.1)
       nio4r (~> 2.0)
-    rack (2.0.9)
-    rack-protection (2.0.8.1)
+    racc (1.5.2)
+    rack (2.2.3)
+    rack-protection (2.1.0)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -178,7 +184,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -188,6 +194,7 @@ GEM
       railties (>= 5.0)
     rsolr (1.1.2)
       builder (>= 2.1.2)
+    ruby2_keywords (0.0.4)
     rubyzip (1.3.0)
     sassc (2.0.1)
       ffi (~> 1.9)
@@ -199,24 +206,24 @@ GEM
       sprockets-rails
       tilt
     scrub_rb (1.0.1)
-    sidekiq (5.2.8)
+    sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
+      rack (~> 2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+      redis (>= 3.3.5, < 4.2)
     simple_token_authentication (1.17.0)
       actionmailer (>= 3.2.6, < 7)
       actionpack (>= 3.2.6, < 7)
       devise (>= 3.2, < 6)
     slop (3.6.0)
-    spring (2.1.0)
+    spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.0.0)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -224,7 +231,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    timecop (0.9.1)
+    timecop (0.9.4)
     traject (2.3.4)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
@@ -244,15 +251,15 @@ GEM
       tilt
       typescript-node (>= 1.6.2)
     typescript-src (1.6.2.0)
-    tzinfo (1.2.7)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    warden (1.2.8)
-      rack (>= 2.0.6)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -260,7 +267,7 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     yajl-ruby (1.4.1)
     yell (2.2.2)
 
@@ -269,7 +276,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_upsert
-  argot (>= 0.3.9)!
+  argot!
   bootstrap (~> 4.3.0)
   byebug
   devise (~> 4.7)
@@ -282,6 +289,8 @@ DEPENDENCIES
   local_time (~> 2.0.0)
   mini_portile2
   mini_racer
+  minitest-stub-const
+  mock_redis (~> 0.27)
   pry-byebug
   puma
   rails (~> 5.1.0)

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -19,6 +19,7 @@
 
     app_user: vagrant
     app_group: "{{ app_user }}"
+
     postgresql_flavor: pgdg
     postgresql_version: 10
     epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest={{ ansible_distribution_major_version }}.noarch.rpm"
@@ -42,7 +43,9 @@
       RAILS_ENV: development
 
     yum_packages:
-      - epel-release
+      - devtoolset-9 # gcc 9, needed for mini_racer
+      - llvm-toolset-7-clang # needed by postgres
+      - jq
       - git
       - curl
       - vim
@@ -63,6 +66,14 @@
       - python-psycopg2
       - lsof
 
+  pre_tasks:
+    - name: Install packages required for roles
+      package:
+        name: 
+          - epel-release
+          - centos-release-scl-rh
+        state: latest
+
   tasks:
 
     - name: Install packages
@@ -79,19 +90,28 @@
     - name: cd to "{{ app_install_dir }}" on login
       lineinfile:
         path: "/home/{{ app_user }}/.bash_profile"
-        line: cd "{{ app_install_dir }}"
+        line: "{{ item }}"
         state: present
         insertafter: EOF
+      with_items:
+        - "source scl_source enable devtoolset-9" # enables gcc-9 for anything we compile
+        - "cd {{ app_install_dir }}"
 
     - name: set up pg_hba.conf
       lineinfile:
         path: "/var/lib/pgsql/{{ postgresql_version }}/data/pg_hba.conf"
         # This is wildly insecure but should be OK in the context
         # of running in Vagrant
-        regexp: '^(local|host\s+all\s+all\s+)peer'
-        line: '\1trust'
+        # local   all             all                                     trust
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         state: present
         backrefs: true
+      with_items:
+        # tcp/ip connections for IPv6 and IPv4
+        - { regexp: '^(host\s+all\s+all\s+[0-9:./]+\s+)ident', line: '\1trust' }
+        - { regexp: '^((?:local|host)\s+all\s+all\s+)peer', line: '\1trust' }
+
       register: pg_hba_edit
 
     - name: restart postgres
@@ -151,7 +171,7 @@
       register: solr_install_stat
 
     - name: Install solr via the solrtask gem
-      shell: ". ~/.bash_profile && bundle exec solrtask -v {{solr_version}} install"
+      shell: 'bash -lc "bundle exec solrtask -v {{solr_version}} install"'
       args:
         chdir: "{{ app_install_dir }}"
       become_user: "{{ app_user }}"
@@ -186,7 +206,7 @@
         - files/*.jar
 
     - name: Start solr
-      shell: "bash -lc 'solrtask -v {{ solr_version }} start'"
+      shell: "bash -lc 'bundle exec solrtask -v {{ solr_version }} start'"
       args:
         chdir: "{{ app_install_dir }}"
       become_user: "{{ app_user }}"
@@ -204,9 +224,19 @@
         chdir: /vagrant
       become_user: "{{ app_user }}"
 
+    - name: Query solr for collections
+      uri:
+        url: http://localhost:8983/solr/admin/collections?action=list
+        return_content: yes
+      register: list_cmd
+
+    - name: show API result
+      debug:
+        msg: "{{ list_cmd }}"
 
     - name: Create solr collection
       shell: "bash -lc 'solr-dir/solr-{{ solr_version }}/bin/solr create_collection -n trlnbib -c trlnbib'"
       args:
         chdir: /vagrant
       become_user: "{{ app_user }}"
+      when: "'trlnbib' not in (list_cmd.content | from_json)['collections']"

--- a/app/services/indexing_processor.rb
+++ b/app/services/indexing_processor.rb
@@ -41,15 +41,18 @@ class IndexingProcessor
       end
     end
     contenter = Argot::Transformer.new(&:content)
+    enricher = Spofford::AuthorityEnricher.new.as_block
     flattener = Argot::Flattener.new.as_block
     suffixer = Argot::Suffixer.new.as_block
 
+    enrichen = Argot::Transformer.new(&enricher)
     flatten = Argot::Transformer.new(&flattener)
     suffix = Argot::Transformer.new(&suffixer)
+
     solr_filter = Spofford::SolrValidator.new do |rec, err|
       logger.info("Record #{rec['id']} rejected: #{err.to_json}")
     end
-    Argot::Pipeline.new | deleter | contenter | flatten | suffix | solr_filter
+    Argot::Pipeline.new | deleter | contenter | enrichen | flatten | suffix | solr_filter
   end
   # rubocop:enable AbcSize, MethodLength
 

--- a/lib/spofford.rb
+++ b/lib/spofford.rb
@@ -4,9 +4,11 @@ require 'spofford/deepstruct'
 
 # Top level namespace for Spofford (trln-ingest) specific features.
 module Spofford
+  autoload :AuthorityEnricher, 'spofford/authority_enricher'
   autoload :Chunker, 'spofford/record_chunker'
   autoload :IngestHelper, 'spofford/ingest_helper'
   autoload :LazyWriter, 'spofford/lazy_writer'
+  autoload :ScriptClassifier, 'spofford/script_classifier'
   autoload :SolrValidator, 'spofford/solr_validator'
   autoload :ArgotViewer, 'spofford/argot_viewer'
 

--- a/lib/spofford/authority_enricher.rb
+++ b/lib/spofford/authority_enricher.rb
@@ -1,0 +1,53 @@
+module Spofford
+  class AuthorityEnricher
+    include Argot::Methods
+
+    REDIS = Redis.new(host: ENV.fetch('REDIS_URL', '127.0.0.1'))
+
+    # NOTE: At present this just handles names fields with an id.
+    #       I could imagine a future implementation where other
+    #       fields are handled and the records are enriched based
+    #       on settings in an (argot-ruby?) configuration file.
+    #       For now keeping it simple.
+    def process(input)
+      authority_values = input.fetch('names', []).map do |name|
+        variant_names(name['id']) if name.fetch('id', nil)
+      end.flatten.compact
+
+      if authority_values.present?
+        input['variant_names'] = authority_values
+      end
+
+      input
+    end
+
+    alias call process
+
+    private
+
+    def variant_names(name_uri)
+      variant_names = variant_names_lookup(name_uri)
+
+      variant_names_vern = (variant_names || []).map do |variant_name|
+        next unless variant_name
+
+        lang = ScriptClassifier.new(variant_name).classify
+        if lang
+          { 'value' => variant_name, 'lang' => lang }
+        else
+          { 'value' => variant_name }
+        end
+      end
+
+      variant_names_vern unless variant_names_vern.empty?
+    end
+
+    def variant_names_lookup(name_uri)
+      variant_name = REDIS.get(
+        name_uri.sub('http://id.loc.gov/authorities/names/', 'lcnaf:')
+      )
+
+      JSON.parse(variant_name) if variant_name
+    end
+  end
+end

--- a/lib/spofford/script_classifier.rb
+++ b/lib/spofford/script_classifier.rb
@@ -1,0 +1,51 @@
+module Spofford
+  class ScriptClassifier
+    attr_reader :value
+
+    def initialize(value)
+      @value = value.to_s
+    end
+
+    def classify
+      case
+      when is_cjk?
+        'cjk'
+      when is_cyrillic?
+        'rus'
+      when is_arabic?
+        'ara'
+      end
+    end
+
+    def is_cjk?
+      classifier(cjk_matcher)
+    end
+
+    def is_cyrillic?
+      classifier(cyrillic_matcher)
+    end
+
+    def is_arabic?
+      classifier(arabic_matcher)
+    end
+
+    private
+
+    def classifier(pattern)
+      char_pattern_match_count = value.scan(pattern).length
+      return true if (char_pattern_match_count.to_f / value.length) > 0.1
+    end
+
+    def cjk_matcher
+      /\p{Han}|\p{Katakana}|\p{Hiragana}|\p{Hangul}/
+    end
+
+    def cyrillic_matcher
+      /\p{Cyrillic}/
+    end
+
+    def arabic_matcher
+      /\p{Arabic}/
+    end
+  end
+end

--- a/lib/spofford/version.rb
+++ b/lib/spofford/version.rb
@@ -1,3 +1,3 @@
 module Spofford
-  VERSION = '0.5.7'.freeze
+  VERSION = '0.5.8'.freeze
 end

--- a/lib/tasks/util.rake
+++ b/lib/tasks/util.rake
@@ -1,4 +1,8 @@
+require 'json'
+require 'open-uri'
+require 'redis'
 require 'sidekiq'
+require 'zip'
 
 namespace :util do
   desc 'Clear sidekiq Redis instance (development only!)'
@@ -12,19 +16,117 @@ namespace :util do
     deleted_records = Document.where(['updated_at <= ? and deleted = ?', 30.days.ago, true])
 
     save_dir = File.join(ENV.fetch('APP_STASH_DIRECTORY', '/opt/trln'), 'deletes')
-    
+
     File.mkdir(save_dir) unless File.directory?(save_dir)
 
     deletes_file_path = File.join(save_dir, "/deletes_#{Time.current.to_date.strftime('%F')}.txt")
 
     File.open(deletes_file_path, 'w') do |f| deleted_records.each { |r| f.puts(r.id) } end
-    
+
     deleted_records.delete_all
   end
 
   desc 'Delete unneeded transactions. Run once a month in production.'
   task delete_transactions: :environment do
-    TransactionPurgeWorker.perform_async()   
+    TransactionPurgeWorker.perform_async()
+  end
+
+  namespace :lcnaf do
+
+    DEFAULT_FILENAME = 'lcnaf.madsrdf.ndjson'
+    DEFAULT_SOURCE = "https://lds-downloads.s3.amazonaws.com/#{DEFAULT_FILENAME}.zip"
+    DEFAULT_DESTINATION = File.join(ENV.fetch('LCNAF_BASE', File.join(ENV['HOME'], 'trln-lcnaf')))
+    REDIS = Redis.new(host: ENV.fetch('REDIS_URL', '127.0.0.1'))
+
+    desc 'Rebuild name authority Redis store'
+    task rebuild: :environment do
+      Rake::Task['util:lcnaf:download'].invoke
+      Rake::Task['util:lcnaf:unzip'].invoke
+      Rake::Task['util:lcnaf:add_to_redis'].invoke
+      Rake::Task['util:lcnaf:cleanup_files'].invoke
+    end
+
+    desc 'Download LC Name Authority File (lcnaf.madsrdf.ndjson.zip)'
+    task download: :environment do
+      FileUtils.mkdir(DEFAULT_DESTINATION) unless File.directory?(DEFAULT_DESTINATION)
+
+      File.open("#{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}.zip", 'w') do |file|
+        puts "Downloading #{DEFAULT_SOURCE} to #{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}.zip"
+        IO.copy_stream(open(DEFAULT_SOURCE), file)
+        puts "Download complete"
+      end
+    end
+
+    desc 'Unzip LC Name Authority File (lcnaf.madsrdf.ndjson)'
+    task unzip: :environment do
+      Zip.on_exists_proc = true
+      Zip::File.open("#{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}.zip") do |zipfile|
+        zipfile.each do |entry|
+          puts "Extracting #{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}.zip to #{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}"
+          entry.extract("#{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}")
+        end
+        puts "Unzip complete"
+      end
+    end
+
+    desc 'Add to Redis variant names from LC Name Authority File (lcnaf.madsrdf.ndjson)'
+    task add_to_redis: :environment do
+      puts "Adding LCNAF variant names to Redis"
+
+      File.open("#{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}", 'r').each do |line|
+        rdf = JSON.parse(line).fetch('@graph', [])
+
+        names = personal_names(rdf) if rdf
+        id = names.first.fetch('@id', '').sub('http://id.loc.gov/authorities/names/', 'lcnaf:') if names.first
+        ids = has_variant_ids(names) if names
+        labels = variant_labels(rdf, ids)
+
+        unless (labels.nil? || labels.empty?)
+          REDIS.set(id, labels)
+          puts "#{id}:#{labels}"
+        end
+      end
+      puts "Completed adding LCNAF variant names to Redis"
+    end
+
+    desc 'Cleanup LC Name Authority files (deletes lcnaf.madsrdf.ndjson & lcnaf.madsrdf.ndjson.zip)'
+    task cleanup_files: :environment do
+      puts "Deleting #{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME} and #{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}.zip"
+      File.delete("#{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}") if File.exists? "#{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}"
+      File.delete("#{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}.zip") if File.exists? "#{DEFAULT_DESTINATION}/#{DEFAULT_FILENAME}.zip"
+      puts "Deleted LCNAF files"
+    end
+
+    desc 'Flush LC Name Authority entries from Redis.'
+    task flush_redis: :environment do
+      REDIS.scan_each(match: 'lcnaf:*').each do |key|
+        REDIS.del(key)
+      end
+    end
+
+    private
+
+    def personal_names(rdf)
+      rdf.select { |v| v.fetch('@type', []).include?('madsrdf:Authority') &&
+                         (v.fetch('@type', []).include?('madsrdf:PersonalName') ||
+                         v.fetch('@type', []).include?('madsrdf:CorporateName'))}
+    end
+
+    def has_variant_ids(names)
+      return if names.nil? || names.empty?
+
+      variants = names&.first&.fetch('madsrdf:hasVariant', [])
+      [variants]&.flatten&.map { |v| v['@id'] }
+    end
+
+
+    def variant_labels(rdf, ids)
+      return unless ids
+
+      ids = rdf.select { |r| ids.include?(r['@id']) }
+      labels = ids.map { |f| f['madsrdf:variantLabel'] }
+      labels.map { |q| q.respond_to?(:fetch) ? q.fetch('@value', nil) : q }
+    end
   end
 end
 


### PR DESCRIPTION
CentOS changed the way they package llvm, so postgres did not want to install.
Enabled SCL to get access to llvm
Use GCC 9 to compile (mini_racer didn't work with GCC 4.8)
Adjust Solr installation to be more idempotent
No version bump as no production code was harmed during the production of this PR.