### PR TITLE
TD-1055 Add Name Authority ID lookup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,9 @@ gem 'git', '~> 1.3.0'
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', '~> 0.12.3', platforms: :ruby
-gem 'mini_racer', platforms: :ruby
+
+# 0.4.0 seems to have problems building on Centos 7
+gem 'mini_racer', '<= 0.3.9',  platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
-    connection_pool (2.2.3)
+    connection_pool (2.2.5)
     crass (1.0.6)
     devise (4.7.3)
       bcrypt (~> 3.0)
@@ -88,14 +88,14 @@ GEM
     dot-properties (0.1.3)
     erubi (1.10.0)
     execjs (2.7.0)
-    ffi (1.14.2)
+    ffi (1.15.0)
     git (1.3.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashids (1.0.5)
     hashie (3.6.0)
     httpclient (2.8.3)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
@@ -115,12 +115,12 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
-    libv8 (8.4.255.0)
+    libv8 (8.4.255.0-x86_64-linux)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     local_time (2.0.1)
-    loofah (2.9.0)
+    loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -131,17 +131,16 @@ GEM
     marc-fastxmlwriter (1.0.0)
       marc (~> 1.0)
     method_source (1.0.0)
-    mini_mime (1.0.2)
+    mini_mime (1.1.0)
     mini_portile2 (2.5.0)
     mini_racer (0.3.1)
       libv8 (~> 8.4.255)
-    minitest (5.14.3)
+    minitest (5.14.4)
     minitest-stub-const (0.6)
     mock_redis (0.27.3)
       ruby2_keywords
-    nio4r (2.5.5)
-    nokogiri (1.11.1)
-      mini_portile2 (~> 2.5.0)
+    nio4r (2.5.7)
+    nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
@@ -152,7 +151,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    puma (5.2.1)
+    puma (5.2.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -271,7 +270,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   active_record_upsert
@@ -287,7 +286,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   local_time (~> 2.0.0)
   mini_portile2
-  mini_racer
+  mini_racer (<= 0.3.9)
   minitest-stub-const
   mock_redis (~> 0.27)
   pry-byebug
@@ -310,4 +309,4 @@ DEPENDENCIES
   yajl-ruby (>= 1.3.1)
 
 BUNDLED WITH
-   2.1.4
+   2.2.11

--- a/app/controllers/name_authority_controller.rb
+++ b/app/controllers/name_authority_controller.rb
@@ -1,0 +1,6 @@
+class NameAuthorityController < ApplicationController
+	include NameAuthorityHelper
+	def index
+		@lookup_value, @lookups = do_lookup
+	end
+end

--- a/app/helpers/name_authority_helper.rb
+++ b/app/helpers/name_authority_helper.rb
@@ -1,0 +1,29 @@
+require 'redis'
+
+module NameAuthorityHelper
+
+  def do_lookup(v=false)
+	lookup_id = params.fetch(:lookup, v)
+	return [lookup_id, []] unless lookup_id
+	
+	lookup_id = canonicalize(lookup_id)
+	result = redis.get(lookup_id)
+	if result.nil?
+		return [lookup_id, []]
+	end
+	[ lookup_id, JSON.parse(result)]
+  end
+
+  def canonicalize(v)
+	v = v.strip
+	return v.gsub(/[^a-zA-Z0-9:]/, '') if v.start_with?('lcnaf:')
+	
+	return "lcnaf:#{$1}" if v =~ /^https?:\/\/id\.loc\.gov\/authorities\/names\/([a-zA-Z0-9]+)/
+
+	return "lcnaf:#{v.gsub(/\W/, '')}"
+  end
+	
+  def redis
+	@redis ||= Redis.new(url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/0'))
+  end
+end

--- a/app/helpers/name_authority_helper.rb
+++ b/app/helpers/name_authority_helper.rb
@@ -1,29 +1,30 @@
+# frozen_string_literal: true
+
 require 'redis'
 
+# Helpers to assist with name authority ID lookup
 module NameAuthorityHelper
+  def do_lookup(val = false)
+    lookup_id = params.fetch(:lookup, val)
+    return [lookup_id, []] unless lookup_id
 
-  def do_lookup(v=false)
-	lookup_id = params.fetch(:lookup, v)
-	return [lookup_id, []] unless lookup_id
-	
-	lookup_id = canonicalize(lookup_id)
-	result = redis.get(lookup_id)
-	if result.nil?
-		return [lookup_id, []]
-	end
-	[ lookup_id, JSON.parse(result)]
+    lookup_id = canonicalize(lookup_id)
+    result = redis.get(lookup_id)
+    return [lookup_id, []] if result.nil?
+
+    [lookup_id, JSON.parse(result)]
   end
 
-  def canonicalize(v)
-	v = v.strip
-	return v.gsub(/[^a-zA-Z0-9:]/, '') if v.start_with?('lcnaf:')
-	
-	return "lcnaf:#{$1}" if v =~ /^https?:\/\/id\.loc\.gov\/authorities\/names\/([a-zA-Z0-9]+)/
+  def canonicalize(val)
+    val = val.strip
+    return val.gsub(/[^a-zA-Z0-9:]/, '') if val.start_with?('lcnaf:')
 
-	return "lcnaf:#{v.gsub(/\W/, '')}"
+    return "lcnaf:#{Regexp.last_match(1)}" if val =~ %r{^https?://id\.loc\.gov/authorities/names/([a-zA-Z0-9]+)}
+
+    "lcnaf:#{val.gsub(/\W/, '')}"
   end
-	
+
   def redis
-	@redis ||= Redis.new(url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/0'))
+    @redis ||= Redis.new(url: ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/0'))
   end
 end

--- a/app/services/indexing_processor.rb
+++ b/app/services/indexing_processor.rb
@@ -49,10 +49,14 @@ class IndexingProcessor
     flatten = Argot::Transformer.new(&flattener)
     suffix = Argot::Transformer.new(&suffixer)
 
+    timestamp = Spofford::Timestamper.new.as_block
+
+    timestamper = Argot::Transformer.new(&timestamp)
+
     solr_filter = Spofford::SolrValidator.new do |rec, err|
       logger.info("Record #{rec['id']} rejected: #{err.to_json}")
     end
-    Argot::Pipeline.new | deleter | contenter | enrichen | flatten | suffix | solr_filter
+    Argot::Pipeline.new | deleter | contenter | enrichen | flatten | suffix |  solr_filter | timestamper
   end
   # rubocop:enable AbcSize, MethodLength
 

--- a/app/views/devise/sessions/_logout.html.erb
+++ b/app/views/devise/sessions/_logout.html.erb
@@ -7,6 +7,7 @@
 		<ul class="navbar-nav mr-auto">
  			<li class='nav-item'><a class='nav-link text-white' href='/'>Home <span class='sr-only'>(current)</span></a></li>
  			<li class='nav-item'><%= link_to('My Account', '/trln/users/me', class: 'nav-link text-white') %></li>
+ 			<li class="nav-item"><%= link_to('Name Authority', '/nameauthority', class: 'nav-link text-white') %></li>
 			<li class='nav-item active'><%= link_to('Logout', destroy_user_session_path, method: :delete, class: 'nav-link text-white') %></li>
 			<li class='nav-item'><%= link_to('Dashboard', '/dashboard', class: 'nav-link text-white') %></li>
 	

--- a/app/views/name_authority/index.html.erb
+++ b/app/views/name_authority/index.html.erb
@@ -1,0 +1,38 @@
+<% content_for :title do %>
+ TRLN Discovery: Name Authority
+<% end %> 
+<h1><%= yield(:title) %></h1>
+ <% if params[:lookup] %>
+  <div>
+  For: <%= params[:lookup] %> (<%= @lookup_value %>)
+  </div>
+  <% if @lookups.empty? %>
+   <em>Not found</em>
+  <% else %>
+   <em>Found <%= pluralize(@lookups.length, 'name') %></em>
+  <ul>
+ <% @lookups.each do |value| %>
+    <li><%= value %></li>
+  <% end %>
+  </ul>
+  <% end %>
+ <% end %>
+  <form action="/nameauthority" method="get">
+  <label>
+    Identifier 
+   <input type='text' placeholder="enter a LCNAF URI"
+     id="lookup" name='lookup'>
+  </label>
+   <br />
+   <input type="submit" value="Look up">
+  </form>
+
+   <p>The following forms are all equivalent:
+
+     <ul>
+       <li>http://id.loc.gov/authorities/names/no2018099999 (URI used in the <kbd>$0</kbd>)</li>
+       <li>https://id.loc.gov/authorities/names/no2018099999.html (web page URL you get redirected to if you enter the above in a browser)</li>
+       <li>no2018099999 (the last component of the URI)</li>
+       <li>lcnaf:no2018099999 (shorthand used by this system)</li>
+     </ul>
+  </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Rails.application.routes.draw do
   get   '/record/search', to: 'documents#search'
   get   '/record/:id' => 'documents#show', :defaults => { format: 'html'}, as: 'show_document'
 
+  get '/nameauthority/', to: 'name_authority#index'
+  get '/nameauthority/:lookup', to: 'name_authority#index'
+
   authenticate :user, ->(u) { u.admin? } do
     mount Sidekiq::Web => '/sidekiq'
   end

--- a/lib/spofford.rb
+++ b/lib/spofford.rb
@@ -11,6 +11,7 @@ module Spofford
   autoload :ScriptClassifier, 'spofford/script_classifier'
   autoload :SolrValidator, 'spofford/solr_validator'
   autoload :ArgotViewer, 'spofford/argot_viewer'
+  autoload :Timestamper, 'spofford/timestamper'
 
   Institution = Struct.new('Owner', :key, :prefix, :name) do
   end

--- a/lib/spofford/timestamper.rb
+++ b/lib/spofford/timestamper.rb
@@ -1,0 +1,25 @@
+module Spofford
+  # Argot transformer that adds a timestamp of ingest 
+  # to all records.
+  class Timestamper
+    include Argot::Methods
+
+    # since the intent is to put this after
+    # all the other filters in the indexing 
+    # pipeline, we'll write the fully
+    # qualified field name; will be available as 'index_date'
+    # in Solr documents
+    FIELD_NAME = 'index_date_dt_stored_single'
+
+    def initialize
+      @timestamp = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+    end
+
+    def process(input)
+      input[FIELD_NAME] = @timestamp
+      input
+    end
+
+    alias call process
+  end
+end

--- a/test/helpers/name_authority_helper_test.rb
+++ b/test/helpers/name_authority_helper_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class NameAuthorityHelperTest < ActionView::TestCase
+	test 'canonicalizes simple values' do
+		assert_equal 'lcnaf:foo', canonicalize('foo')
+	end
+
+	test 'leaves lcnaf: entries alone' do
+		assert_equal 'lcnaf:no1238', canonicalize('lcnaf:no1238')
+	end
+
+	test 'removes invalid characters' do
+		assert_equal 'lcnaf:no1444', canonicalize('no?14:\44')
+	end
+
+	test 'canonicalizes id.loc.gov URIs' do
+		assert_equal('lcnaf:no2018099999', canonicalize('http://id.loc.gov/authorities/names/no2018099999'))
+	end
+
+	test 'canonicalizes id.loc.gov web page URLs' do
+		assert_equal('lcnaf:no2018099999', canonicalize('https://id.loc.gov/authorities/names/no2018099999.html'))
+	end
+
+
+end

--- a/test/helpers/name_authority_helper_test.rb
+++ b/test/helpers/name_authority_helper_test.rb
@@ -1,25 +1,25 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class NameAuthorityHelperTest < ActionView::TestCase
-	test 'canonicalizes simple values' do
-		assert_equal 'lcnaf:foo', canonicalize('foo')
-	end
+  test 'canonicalizes simple values' do
+    assert_equal 'lcnaf:foo', canonicalize('foo')
+  end
 
-	test 'leaves lcnaf: entries alone' do
-		assert_equal 'lcnaf:no1238', canonicalize('lcnaf:no1238')
-	end
+  test 'leaves lcnaf: entries alone' do
+    assert_equal 'lcnaf:no1238', canonicalize('lcnaf:no1238')
+  end
 
-	test 'removes invalid characters' do
-		assert_equal 'lcnaf:no1444', canonicalize('no?14:\44')
-	end
+  test 'removes invalid characters' do
+    assert_equal 'lcnaf:no1444', canonicalize('no?14:\44')
+  end
 
-	test 'canonicalizes id.loc.gov URIs' do
-		assert_equal('lcnaf:no2018099999', canonicalize('http://id.loc.gov/authorities/names/no2018099999'))
-	end
+  test 'canonicalizes id.loc.gov URIs' do
+    assert_equal('lcnaf:no2018099999', canonicalize('http://id.loc.gov/authorities/names/no2018099999'))
+  end
 
-	test 'canonicalizes id.loc.gov web page URLs' do
-		assert_equal('lcnaf:no2018099999', canonicalize('https://id.loc.gov/authorities/names/no2018099999.html'))
-	end
-
-
+  test 'canonicalizes id.loc.gov web page URLs' do
+    assert_equal('lcnaf:no2018099999', canonicalize('https://id.loc.gov/authorities/names/no2018099999.html'))
+  end
 end

--- a/test/lib/spofford_test.rb
+++ b/test/lib/spofford_test.rb
@@ -70,5 +70,12 @@ class ScriptClassifierTest < ActiveSupport::TestCase
   test 'CJK characters are classified' do
     assert Spofford::ScriptClassifier.new('東京').classify == 'cjk'
   end
+
+  class TimestamperTest < ActiveSupport::TestCase
+    test 'Timestamper adds field to document' do
+      i = {}
+      assert Spofford::Timestamper.new.process(i).include?(Spofford::Timestamper::FIELD_NAME)
+    end
+  end
 end
 


### PR DESCRIPTION
Adds a "Name Authority" entry on the menu bar and a lookup page for LCNAF IDs.


![image](https://user-images.githubusercontent.com/3475327/115747451-46cf1b80-a363-11eb-9c42-1ced12a4ebd2.png)

Lookup page example:

![image](https://user-images.githubusercontent.com/3475327/115747695-80a02200-a363-11eb-9f1f-e0214577a41c.png)

