### PR TITLE
rebundle with 2.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     concurrent-ruby (1.1.8)
     connection_pool (2.2.5)
     crass (1.0.6)
-    devise (4.7.3)
+    devise (4.8.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -119,7 +119,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
-    libv8 (8.4.255.0-x86_64-linux)
+    libv8 (8.4.255.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -137,15 +137,16 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     mini_racer (0.3.1)
       libv8 (~> 8.4.255)
     minitest (5.14.4)
     minitest-stub-const (0.6)
-    mock_redis (0.27.3)
+    mock_redis (0.28.0)
       ruby2_keywords
     nio4r (2.5.7)
-    nokogiri (1.11.3-x86_64-linux)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
@@ -276,7 +277,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   active_record_upsert
@@ -315,4 +316,4 @@ DEPENDENCIES
   yajl-ruby (>= 1.3.1)
 
 BUNDLED WITH
-   2.2.11
+   2.1.4


### PR DESCRIPTION
Bundler 2.1.4 is what's installed on target, so `Gemfile.lock` should match that.