### PR TITLE
Update the lcnaf rake task to use a GZipReader to open the file

### DIFF
--- a/lib/spofford/version.rb
+++ b/lib/spofford/version.rb
@@ -1,3 +1,3 @@
 module Spofford
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end


### PR DESCRIPTION
The file used for building our name authority processing database has been updated. The new link is here: https://id.loc.gov/download/authorities/names.madsrdf.jsonld.gz. Additionally, in this release, we have incorporated an update to utilize a GZipReader for file opening.