### PR TITLE
Update argot ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -54,7 +54,13 @@ jobs:
         run: |
           sudo apt-get -yqq install libpq-dev
           yes | gem update --system --force
-                  
+
+      - name: Update Rubygems
+        run: gem update --system 3.3.22
+
+      - name: Install Bundler
+        run: gem install bundler
+
       - name: Install dependencies
         run: |
           bundler install

--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ gem 'active_record_upsert', platform: :mri
 # :github specifier defaults to using git:// protocol, which generates
 # warnings. See comment at top of file.
 
-gem 'argot', github: 'trln/argot-ruby', tag: 'v1.0.7'
+gem 'argot', github: 'trln/argot-ruby', tag: 'v1.3.1'
 
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,14 @@
 GIT
   remote: https://github.com/trln/argot-ruby.git
-  revision: cdab78d2b5a84f46fce8d3f59d77614980678ee9
-  tag: v1.0.7
+  revision: eef83e9b9918edc9a6c770dfeef44fc37a21f011
+  tag: v1.3.1
   specs:
-    argot (1.0.7)
-      nokogiri (~> 1.10)
+    argot (1.3.1)
+      redis
       rsolr (~> 1.1, >= 1.1.2)
       rubyzip (~> 1.2)
       thor (~> 1.0)
-      traject (~> 2.0)
-      yajl-ruby (~> 1.2, >= 1.2.1)
+      yajl-ruby (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -85,10 +84,10 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.16.1, < 2)
       sassc-rails (>= 2.0.0)
-    builder (3.2.4)
+    builder (3.3.0)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
@@ -98,15 +97,12 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    dot-properties (0.1.3)
     erubi (1.12.0)
     execjs (2.9.1)
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashids (1.0.6)
-    hashie (3.6.0)
-    httpclient (2.8.3)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -140,16 +136,10 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marc (1.2.0)
-      rexml
-      scrub_rb (>= 1.0.1, < 2)
-      unf
-    marc-fastxmlwriter (1.1.0)
-      marc (~> 1.0)
     marcel (1.0.4)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.6)
+    mini_portile2 (2.8.8)
     minitest (5.22.3)
     minitest-stub-const (0.6)
     mock_redis (0.41.0)
@@ -177,7 +167,7 @@ GEM
       pry (>= 0.13, < 0.15)
     puma (6.4.2)
       nio4r (~> 2.0)
-    racc (1.7.3)
+    racc (1.8.1)
     rack (2.2.9)
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
@@ -220,7 +210,6 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.6)
     rsolr (1.1.2)
       builder (>= 2.1.2)
     rubyzip (1.3.0)
@@ -233,7 +222,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scrub_rb (1.0.1)
     sidekiq (5.2.10)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -243,7 +231,6 @@ GEM
       actionmailer (>= 3.2.6, < 8)
       actionpack (>= 3.2.6, < 8)
       devise (>= 3.2, < 6)
-    slop (3.6.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -257,19 +244,10 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.6.9)
       mini_portile2 (~> 2.8.0)
-    thor (1.3.1)
+    thor (1.3.2)
     tilt (2.3.0)
     timecop (0.9.8)
     timeout (0.4.1)
-    traject (2.3.4)
-      concurrent-ruby (>= 0.8.0)
-      dot-properties (>= 0.1.1)
-      hashie (~> 3.1)
-      httpclient (~> 2.5)
-      marc (~> 1.0)
-      marc-fastxmlwriter (~> 1.0)
-      slop (>= 3.4.5, < 4.0)
-      yell
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -279,9 +257,6 @@ GEM
       tzinfo (>= 1.0.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.9.1)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -293,7 +268,6 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     yajl-ruby (1.4.3)
-    yell (2.2.2)
     zeitwerk (2.6.13)
 
 PLATFORMS

--- a/lib/spofford/authority_enricher.rb
+++ b/lib/spofford/authority_enricher.rb
@@ -52,7 +52,7 @@ module Spofford
 
     def variant_names_lookup(name_uri)
       variant_name = REDIS.get(
-        name_uri.sub('http://id.loc.gov/authorities/names/', 'lcnaf:')
+        name_uri.gsub(%r{https?://id.loc.gov/authorities/names/}, 'lcnaf:')
       )
 
       JSON.parse(variant_name) if variant_name

--- a/lib/spofford/version.rb
+++ b/lib/spofford/version.rb
@@ -1,3 +1,3 @@
 module Spofford
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.0.5'.freeze
 end


### PR DESCRIPTION
- Handle both `http` and `https` in the name authority URLs, treating them as identical.
- Upgrade Argot to pull version 1.3.1 (most recent).
- Update the CI configuration to ensure all jobs pass.